### PR TITLE
Activate features

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,13 +13,12 @@ source:
         - def_snprintf.patch  # [win]
 
 build:
+    number: 3
     features:
         - vc9  # [win and py27]
         - vc10  # [win and py34]
         - vc14  # [win and py35]
 
-build:
-    number: 3
 
 requirements:
     build:


### PR DESCRIPTION
My `copy-and-pasta` was disabling features and that is probably the cause of my failures with `gdal` and `Python 3.4`.