### PR TITLE
Shadow `defaults` `libtiff` so ours is used

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
         - def_snprintf.patch  # [win]
 
 build:
-    number: 3
+    number: 1
     features:
         - vc9  # [win and py27]
         - vc10  # [win and py34]


### PR DESCRIPTION
This tricks the solver into not seeing the package in `defaults` (libtiff 4.0.6 1). Instead it will see ours. However, this package will never be used. In fact, the solver will see this and then see the newer version (libtiff 4.0.6 3) and upgrade outright. This requires no additional changes to any packages that expect to use our version of `libtiff` beyond whatever pinning is already done. This can be reverted after the package is built.