### PR TITLE
Add zlib and jpeg to Windows and use toolchain

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -2,8 +2,18 @@ set LIB=%LIB%;%LIBRARY_LIB%
 set INCLUDE=%INCLUDE%;%LIBRARY_INC%
 set LIBPATH=%LIBPATH%;%LIBRARY_LIB%
 
+:: Tell the build where to find zlib and jpeg
+set BLD_OPTS=JPEG_SUPPORT=1 ^
+    JPEGDIR=%LIBRARY_PREFIX% ^
+    JPEG_INCLUDE=%LIBRARY_INC% ^
+    JPEG_LIB=%LIBRARY_LIB%\libjpeg.lib ^
+    ZIP_SUPPORT=1 ^
+    ZLIBDIR=%LIBRARY_PREFIX% ^
+    ZLIB_INCLUDE=%LIBRARY_INC% ^
+    ZLIB_LIB=%LIBRARY_LIB%\zlib.lib
+
 :: Build.
-nmake /f Makefile.vc
+nmake /f Makefile.vc %BLD_OPTS%
 if errorlevel 1 exit 1
 
 :: Install.

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,7 +1,16 @@
 #!/bin/bash
 
+# FIXME: This is a hack to make sure the environment is activated.
+# The reason this is required is due to the conda-build issue
+# mentioned below.
+#
+# https://github.com/conda/conda-build/issues/910
+#
+source activate "${CONDA_DEFAULT_ENV}"
+
 if [[ $(uname) == Darwin ]]; then
   export LIBRARY_SEARCH_VAR=DYLD_FALLBACK_LIBRARY_PATH
+  export CXX="${CXX} -stdlib=libc++"
 elif [[ $(uname) == Linux ]]; then
   export LIBRARY_SEARCH_VAR=LD_LIBRARY_PATH
 fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,6 +24,7 @@ requirements:
     build:
         - python  # [win]
         - cmake  # [win]
+        - toolchain
         - zlib 1.2*
         - jpeg 9*
         - xz 5.0.*  # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
         - def_snprintf.patch  # [win]
 
 build:
-    number: 4
+    number: 5
     features:
         - vc9  # [win and py27]
         - vc10  # [win and py34]


### PR DESCRIPTION
This PR fixes https://github.com/conda-forge/libtiff-feedstock/issues/13. 

It also updates the Unix build to use `toolchain` which should fix linking issues on OSX with the C++ lib. Ping @jakirkham 