### PR TITLE
remove symlinks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
 
       conda config --set show_channel_urls true
       conda update --yes conda
-      conda install --yes conda-build=1.20.0 jinja2 anaconda-client
+      conda install --yes conda-build jinja2 anaconda-client
       conda config --add channels conda-forge
       
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
         - def_snprintf.patch  # [win]
 
 build:
-    number: 5
+    number: 6
     features:
         - vc9  # [win and py27]
         - vc10  # [win and py34]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
         - def_snprintf.patch  # [win]
 
 build:
-    number: 6
+    number: 5
     features:
         - vc9  # [win and py27]
         - vc10  # [win and py34]


### PR DESCRIPTION
I forgot to unpin `conda-build` when using `toolchain` which means symlinks get left in. This should fix it.

cc @jakirkham 