### PR TITLE
Update xz pinning

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
         - def_snprintf.patch  # [win]
 
 build:
-    number: 5
+    number: 6
     features:
         - vc9  # [win and py27]
         - vc10  # [win and py34]
@@ -27,11 +27,11 @@ requirements:
         - toolchain
         - zlib 1.2*
         - jpeg 9*
-        - xz 5.0.*  # [not win]
+        - xz 5.2.*  # [not win]
     run:
         - zlib 1.2*
         - jpeg 9*
-        - xz 5.0.*  # [not win]
+        - xz 5.2.*  # [not win]
 
 test:
     commands:


### PR DESCRIPTION
@pelson this would help me a lot with all the issues I am having when `conda` pulls `libtiff` with `jpeg 8*` instead of `jpeg 9*`. That happens because `defaults` updated their `xz` to `5.2.2` and both Python and `libtiff` depends on `xz`.

I cannot really understand why conda does not choose to downgrade `Python` and honor the pinnings, but I hope that updating it here may help get our stack back on track.

Ideally we should re-compiled Python with `xz 5.2.2` (ping @jjhelmus) and update the pins everywhere.