### PR TITLE
Re-add patch for CVE-2017-11613, put Windows DLL name back to tiff.dl…

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,13 +1,17 @@
 mkdir build_%c_compiler%
 cd build_%c_compiler%
 
-cmake -G"%CMAKE_GENERATOR%" ^
-      -DCMAKE_INSTALL_PREFIX="%LIBRARY_PREFIX%" ^
-      -DCMAKE_BUILD_TYPE=Release ^
-      -DCMAKE_C_FLAGS="%CFLAGS% -DWIN32" ^
-      -DCMAKE_CXX_FLAGS="%CXXFLAGS% -EHsc" ^
-      %SRC_DIR%
+cmake -G"%CMAKE_GENERATOR%"                      ^
+      -DCMAKE_INSTALL_PREFIX="%LIBRARY_PREFIX%"  ^
+      -DCMAKE_BUILD_TYPE=Release                 ^
+      -DCMAKE_C_FLAGS="%CFLAGS% -DWIN32"         ^
+      -DCMAKE_CXX_FLAGS="%CXXFLAGS% -EHsc"       ^
+      -DCMAKE_SHARED_LIBRARY_PREFIX=""           ^
+      ..
 if errorlevel 1 exit /b 1
 
 cmake --build . --target install --config Release
 if errorlevel 1 exit /b 1
+
+copy "%LIBRARY_PREFIX%"\bin\tiff.dll "%LIBRARY_PREFIX%"\bin\libtiff.dll
+copy "%LIBRARY_PREFIX%"\bin\tiffxx.dll "%LIBRARY_PREFIX%"\bin\libtiffxx.dll

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,10 +43,8 @@ test:
   commands:
     - test -f ${PREFIX}/lib/libtiff.a                            # [unix]
     - test -f ${PREFIX}/lib/libtiffxx.a                          # [unix]
-    - test -f ${PREFIX}/lib/libtiff.so                           # [linux]
-    - test -f ${PREFIX}/lib/libtiffxx.so                         # [linux]
-    - test -f ${PREFIX}/lib/libtiff.dylib                        # [osx]
-    - test -f ${PREFIX}/lib/libtiffxx.dylib                      # [osx]
+    - test -f ${PREFIX}/lib/libtiff${SHLIB_EXT}                  # [unix]
+    - test -f ${PREFIX}/lib/libtiffxx${SHLIB_EXT}                # [unix]
     - if not exist %PREFIX%\\Library\\bin\\tiff.dll exit 1       # [win]
     - if not exist %PREFIX%\\Library\\bin\\tiffxx.dll exit 1     # [win]
     - if not exist %PREFIX%\\Library\\bin\\libtiff.dll exit 1    # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,24 +5,31 @@ package:
   version: {{ version }}
 
 source:
-  url: http://download.osgeo.org/libtiff/tiff-{{ version }}.tar.gz
+  url: https://download.osgeo.org/libtiff/tiff-{{ version }}.tar.gz
   sha256: 2c52d11ccaf767457db0c46795d9c7d1a8d8f76f68b0b800a3dfe45786b996e4
   patches:
+    - patches/0001-CVE-2017-11613_part1.patch
+    - patches/0002-CVE-2017-11613_part2.patch
     - patches/fix_TIFFReadRawStrip_man_page_typo.patch
     - patches/fixed_lossless_webp_compression_config.patch
 
 build:
-  number: 1000
+  number: 1001
   # Does a very good job of maintaining compatibility.
   #    https://abi-laboratory.pro/tracker/timeline/libtiff/
   run_exports:
     - {{ pin_subpackage('libtiff', max_pin='x') }}
+  missing_dso_whitelist:
+    # Only used by libtiff,bin/tiffgt (a viewer), which is ok.
+    - /opt/X11/lib/libGL.1.dylib
+    - /opt/X11/lib/libglut.3.dylib
 
 requirements:
   build:
-    - cmake  # [win]
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
+    - cmake   # [win]
+    - make    # [not win]
   host:
     - zlib
     - jpeg
@@ -34,20 +41,31 @@ requirements:
 
 test:
   commands:
-    - test -f ${PREFIX}/lib/libtiff.a  # [not win]
-    - test -f ${PREFIX}/lib/libtiffxx.a  # [not win]
-    - test -f ${PREFIX}/lib/libtiff${SHLIB_EXT}  # [not win]
-    - test -f ${PREFIX}/lib/libtiffxx${SHLIB_EXT}  # [not win]
+    - test -f ${PREFIX}/lib/libtiff.a                            # [unix]
+    - test -f ${PREFIX}/lib/libtiffxx.a                          # [unix]
+    - test -f ${PREFIX}/lib/libtiff.so                           # [linux]
+    - test -f ${PREFIX}/lib/libtiffxx.so                         # [linux]
+    - test -f ${PREFIX}/lib/libtiff.dylib                        # [osx]
+    - test -f ${PREFIX}/lib/libtiffxx.dylib                      # [osx]
+    - if not exist %PREFIX%\\Library\\bin\\tiff.dll exit 1       # [win]
+    - if not exist %PREFIX%\\Library\\bin\\tiffxx.dll exit 1     # [win]
+    - if not exist %PREFIX%\\Library\\bin\\libtiff.dll exit 1    # [win]
+    - if not exist %PREFIX%\\Library\\bin\\libtiffxx.dll exit 1  # [win]
 
 about:
-  home: http://www.remotesensing.org/libtiff/
+  home: http://www.libtiff.org/
   license: HPND
   license_file: COPYRIGHT
   summary: 'Support for the Tag Image File Format (TIFF).'
+  description: |
+    This software provides support for the Tag Image File Format (TIFF), a
+    widely used format for storing image data.
+  doc_url: http://www.libtiff.org/document.html
 
 extra:
    recipe-maintainers:
     - jakirkham
+    - mingwandroid
+    - msarahan
     - ocefpaf
     - stuarteberg
-    - msarahan

--- a/recipe/patches/0001-CVE-2017-11613_part1.patch
+++ b/recipe/patches/0001-CVE-2017-11613_part1.patch
@@ -1,0 +1,40 @@
+From 3719385a3fac5cfb20b487619a5f08abbf967cf8 Mon Sep 17 00:00:00 2001
+From: Even Rouault <even.rouault@spatialys.com>
+Date: Sun, 11 Mar 2018 11:14:01 +0100
+Subject: [PATCH] ChopUpSingleUncompressedStrip: avoid memory exhaustion (CVE-2017-11613)
+
+In ChopUpSingleUncompressedStrip(), if the computed number of strips is big
+enough and we are in read only mode, validate that the file size is consistent
+with that number of strips to avoid useless attempts at allocating a lot of
+memory for the td_stripbytecount and td_stripoffset arrays.
+
+Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2724
+---
+ libtiff/tif_dirread.c | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/libtiff/tif_dirread.c b/libtiff/tif_dirread.c
+index 3fc0c8e..1a3259c 100644
+--- a/libtiff/tif_dirread.c
++++ b/libtiff/tif_dirread.c
+@@ -5698,6 +5698,17 @@ ChopUpSingleUncompressedStrip(TIFF* tif)
+         if( nstrips == 0 )
+             return;
+ 
++        /* If we are going to allocate a lot of memory, make sure that the */
++        /* file is as big as needed */
++        if( tif->tif_mode == O_RDONLY &&
++            nstrips > 1000000 &&
++            (tif->tif_dir.td_stripoffset[0] >= TIFFGetFileSize(tif) ||
++             tif->tif_dir.td_stripbytecount[0] >
++                    TIFFGetFileSize(tif) - tif->tif_dir.td_stripoffset[0]) )
++        {
++            return;
++        }
++
+ 	newcounts = (uint64*) _TIFFCheckMalloc(tif, nstrips, sizeof (uint64),
+ 				"for chopped \"StripByteCounts\" array");
+ 	newoffsets = (uint64*) _TIFFCheckMalloc(tif, nstrips, sizeof (uint64),
+--
+libgit2 0.27.0
+

--- a/recipe/patches/0002-CVE-2017-11613_part2.patch
+++ b/recipe/patches/0002-CVE-2017-11613_part2.patch
@@ -1,0 +1,33 @@
+From 7a092f8af2568d61993a8cc2e7a35a998d7d37be Mon Sep 17 00:00:00 2001
+From: Even Rouault <even.rouault@spatialys.com>
+Date: Sat, 17 Mar 2018 09:36:29 +0100
+Subject: [PATCH] ChopUpSingleUncompressedStrip: avoid memory exhaustion (CVE-2017-11613)
+
+Rework fix done in 3719385a3fac5cfb20b487619a5f08abbf967cf8 to work in more
+cases like https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=6979.
+Credit to OSS Fuzz
+
+Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2724
+---
+ libtiff/tif_dirread.c | 5 ++---
+ 1 file changed, 2 insertions(+), 3 deletions(-)
+
+diff --git a/libtiff/tif_dirread.c b/libtiff/tif_dirread.c
+index 1a3259c..6baa7b3 100644
+--- a/libtiff/tif_dirread.c
++++ b/libtiff/tif_dirread.c
+@@ -5702,9 +5702,8 @@ ChopUpSingleUncompressedStrip(TIFF* tif)
+         /* file is as big as needed */
+         if( tif->tif_mode == O_RDONLY &&
+             nstrips > 1000000 &&
+-            (tif->tif_dir.td_stripoffset[0] >= TIFFGetFileSize(tif) ||
+-             tif->tif_dir.td_stripbytecount[0] >
+-                    TIFFGetFileSize(tif) - tif->tif_dir.td_stripoffset[0]) )
++            (offset >= TIFFGetFileSize(tif) ||
++             stripbytes > (TIFFGetFileSize(tif) - offset) / (nstrips - 1)) )
+         {
+             return;
+         }
+--
+libgit2 0.27.0
+


### PR DESCRIPTION
…l, providing libtiff.dll too for compat.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] Ensured the license file is being packaged.

Fixes https://github.com/conda-forge/libtiff-feedstock/issues/35

We also copy `tiff.dll` to `libtiff.dll` to maintain compat. with Anaconda Defaults (which will also adopt this PR, more or less, just without any requirements/run).