### PR TITLE
Remove runtime dependency on libwebp

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ source:
     fn: hopper_lzw.tif
 
 build:
-  number: 5
+  number: 6
   skip: True  # [win and vc<14]
   # Does a very good job of maintaining compatibility.
   #    https://abi-laboratory.pro/tracker/timeline/libtiff/
@@ -56,7 +56,7 @@ requirements:
     - jpeg
     - xz
     - zstd
-    - libwebp  # [linux or osx]
+    - libwebp-base  # [linux or osx]
 
 test:
   requires:


### PR DESCRIPTION
libwebp no longer contains the libraries that libtiff needs. The libraries are strictly in libwebp-base. Having libtiff depend on libwebp causes a circular dependency which prevents libwebp from building.

Related to conda-forge/libwebp-feedstock#26, conda-forge/libwebp-feedstock#27, conda-forge/libwebp-feedstock#28
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
