### PR TITLE
Add test for CMake metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@
 /build_artifacts
 
 *.pyc
+
+# Rattler-build's artifacts are in `output` when not specifying anything.
+/output

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Package license: HPND
 
 Summary: Support for the Tag Image File Format (TIFF).
 
+Development: https://gitlab.com/libtiff/libtiff
+
 Documentation: http://www.libtiff.org/document.html
 
 This software provides support for the Tag Image File Format (TIFF), a

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -71,6 +71,7 @@ about:
     This software provides support for the Tag Image File Format (TIFF), a
     widely used format for storing image data.
   doc_url: http://www.libtiff.org/document.html
+  dev_url: https://gitlab.com/libtiff/libtiff
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
     - patches/use_unix_io.patch
 
 build:
-  number: 3
+  number: 4
   # Does a very good job of maintaining compatibility.
   # Except broke abi between 4.4 and 4.5.0
   #    https://github.com/conda-forge/libtiff-feedstock/issues/77
@@ -51,6 +51,15 @@ test:
   #   - pillow >=8
   #   - py-opencv >=4
   #   - tifffile
+  source_files:
+    # see https://gitlab.com/libtiff/libtiff/-/blob/master/build/test_cmake/CMakeLists.txt
+    - build/test_cmake
+  requires:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - cmake
+    - ninja
+    - pkg-config
   commands:
     - test ! -f ${PREFIX}/lib/libtiff.a  # [not win]
     - test ! -f ${PREFIX}/lib/libtiffxx.a  # [not win]
@@ -61,6 +70,12 @@ test:
     # It seems that libtiffxx does not have a dll on windows
     # https://gitlab.com/libtiff/libtiff/-/merge_requests/338
     - if not exist %PREFIX%\\Library\\lib\\tiffxx.lib exit 1  # [win]
+
+    # test correctness of CMake metadata
+    - cd build/cmake_test
+    - cmake -GNinja $CMAKE_ARGS .   # [unix]
+    - cmake -GNinja %CMAKE_ARGS% .  # [win]
+    - cmake --build .
 
 about:
   home: http://www.libtiff.org/


### PR DESCRIPTION
seeing some missing tiff symbols in https://github.com/conda-forge/dcmtk-feedstock/pull/13, because the metadata for the tiff libraries appears to be empty (or using a too-old CMake notation). In any case, it doesn't hurt to add a test here, and as it turns out, the exact same test I wanted to write already exists upstream, so just use that.